### PR TITLE
feat: replace omec pfcp with go-pfcp (very partial)

### DIFF
--- a/context/context.go
+++ b/context/context.go
@@ -77,7 +77,7 @@ type SMFContext struct {
 	PodIp                 string
 
 	StaticIpInfo             *[]factory.StaticIpInfo
-	CPNodeID                 pfcpType.NodeID
+	CPNodeID                 *NodeID
 	UDMProfile               models.NfProfile
 	NrfCacheEvictionInterval time.Duration
 	SBIPort                  int
@@ -86,6 +86,13 @@ type SMFContext struct {
 
 	// For ULCL
 	ULCLSupport bool
+}
+
+// NodeID
+type NodeID struct {
+	Ipv4 string
+	Ipv6 string
+	Fqdn string
 }
 
 // RetrieveDnnInformation gets the corresponding dnn info from S-NSSAI and DNN

--- a/context/pfcp_rules.go
+++ b/context/pfcp_rules.go
@@ -7,9 +7,9 @@ package context
 
 import (
 	"fmt"
+	"net"
 
 	"github.com/omec-project/pfcp/pfcpType"
-	"github.com/omec-project/util/util_3gpp"
 )
 
 const (
@@ -23,7 +23,7 @@ type RuleState uint8
 
 // Packet Detection Rule. Table 7.5.2.2-1
 type PDR struct {
-	OuterHeaderRemoval *pfcpType.OuterHeaderRemoval
+	OuterHeaderRemoval *OuterHeaderRemoval
 
 	FAR *FAR
 	URR *URR
@@ -37,12 +37,45 @@ type PDR struct {
 
 // Packet Detection. 7.5.2.2-2
 type PDI struct {
-	LocalFTeid      *pfcpType.FTEID
-	UEIPAddress     *pfcpType.UEIPAddress
-	SDFFilter       *pfcpType.SDFFilter
+	LocalFTeid      *FTEID
+	UEIPAddress     *UEIPAddress
+	SDFFilter       *SDFFilter
 	ApplicationID   string
-	NetworkInstance util_3gpp.Dnn
-	SourceInterface pfcpType.SourceInterface
+	NetworkInstance string
+	SourceInterface uint8
+}
+
+// F-TEID.
+type FTEID struct {
+	Flags uint8
+	Teid  uint32
+	V4    net.IP
+	V6    net.IP
+	Chid  uint8
+}
+
+// UE IP Address.
+type UEIPAddress struct {
+	Flags uint8
+	V4    string
+	V6    string
+	V6d   uint8
+	V6pl  uint8
+}
+
+// SDFFilter
+type SDFFilter struct {
+	Fd  string
+	Ttc string
+	Spi string
+	Fl  string
+	Fid uint32
+}
+
+// Outer Header Removal.
+type OuterHeaderRemoval struct {
+	Desc uint8
+	Ext  uint8
 }
 
 // Forwarding Action Rule. 7.5.2.3-1
@@ -53,16 +86,34 @@ type FAR struct {
 	State RuleState
 	FARID uint32
 
-	ApplyAction pfcpType.ApplyAction
+	ApplyAction *ApplyAction
+}
+
+type ApplyAction struct {
+	Dupl bool
+	Nocp bool
+	Buff bool
+	Forw bool
+	Drop bool
 }
 
 // Forwarding Parameters. 7.5.2.3-2
 type ForwardingParameters struct {
-	OuterHeaderCreation  *pfcpType.OuterHeaderCreation
+	OuterHeaderCreation  *OuterHeaderCreation
 	PFCPSMReqFlags       *pfcpType.PFCPSMReqFlags
 	ForwardingPolicyID   string
-	NetworkInstance      util_3gpp.Dnn
-	DestinationInterface pfcpType.DestinationInterface
+	NetworkInstance      string
+	DestinationInterface uint8
+}
+
+type OuterHeaderCreation struct {
+	Desc uint16
+	Teid uint32
+	V4   string
+	V6   string
+	Port uint16
+	Ctag uint32
+	Stag uint32
 }
 
 // Buffering Action Rule 7.5.2.6-1

--- a/context/upf.go
+++ b/context/upf.go
@@ -77,7 +77,7 @@ type UPF struct {
 	teidGenerator  *idgenerator.IDGenerator
 
 	RecoveryTimeStamp pfcpType.RecoveryTimeStamp
-	NodeID            pfcpType.NodeID
+	NodeID            NodeID
 	UPIPInfo          pfcpType.UserPlaneIPResourceInformation
 	UPFStatus         UPFStatus
 	uuid              uuid.UUID

--- a/go.mod
+++ b/go.mod
@@ -22,6 +22,7 @@ require (
 	github.com/sirupsen/logrus v1.9.3
 	github.com/stretchr/testify v1.9.0
 	github.com/urfave/cli v1.22.15
+	github.com/wmnsk/go-pfcp v0.0.24
 	gopkg.in/yaml.v2 v2.4.0
 )
 

--- a/go.sum
+++ b/go.sum
@@ -336,6 +336,8 @@ github.com/ugorji/go/codec v1.2.12 h1:9LC83zGrHhuUA9l16C9AHXAqEV/2wBQ4nkvumAE65E
 github.com/ugorji/go/codec v1.2.12/go.mod h1:UNopzCgEMSXjBc6AOMqYvWC1ktqTAfzJZUZgYf6w6lg=
 github.com/urfave/cli v1.22.15 h1:nuqt+pdC/KqswQKhETJjo7pvn/k4xMUxgW6liI7XpnM=
 github.com/urfave/cli v1.22.15/go.mod h1:wSan1hmo5zeyLGBjRJbzRTNk8gwoYa2B9n4q9dmRIc0=
+github.com/wmnsk/go-pfcp v0.0.24 h1:sv4F3U/IphsPUMXMkTJW877CRvXZ1sF5onWHGBvxx/A=
+github.com/wmnsk/go-pfcp v0.0.24/go.mod h1:8EUVvOzlz25wkUs9D8STNAs5zGyIo5xEUpHQOUZ/iSg=
 github.com/xdg-go/pbkdf2 v1.0.0 h1:Su7DPu48wXMwC3bs7MCNG+z4FhcyEuz5dlvchbq0B0c=
 github.com/xdg-go/pbkdf2 v1.0.0/go.mod h1:jrpuAogTd400dnrH08LKmI/xc1MbPOebTwRqcT5RDeI=
 github.com/xdg-go/scram v1.1.1/go.mod h1:RaEWvsqvNKKvBPvcKeFjrG2cJqOkHTiyTpzz23ni57g=

--- a/pfcp/message/send.go
+++ b/pfcp/message/send.go
@@ -33,6 +33,7 @@ import (
 	"github.com/omec-project/smf/msgtypes/pfcpmsgtypes"
 	"github.com/omec-project/smf/pfcp/adapter"
 	"github.com/omec-project/smf/pfcp/udp"
+	"github.com/wmnsk/go-pfcp/message"
 )
 
 var seq uint32
@@ -280,7 +281,7 @@ func SendPfcpSessionEstablishmentRequest(
 	ctx *smf_context.SMContext,
 	pdrList []*smf_context.PDR, farList []*smf_context.FAR, barList []*smf_context.BAR, qerList []*smf_context.QER, upfPort uint16,
 ) {
-	pfcpMsg, err := BuildPfcpSessionEstablishmentRequest(upNodeID, ctx, pdrList, farList, barList, qerList)
+	pfcpMsg, err := BuildPfcpSessionEstablishmentRequest(upNodeID, ctx, pdrList, farList, barList, qerList, 0, getSeqNumber(), 0)
 	if err != nil {
 		ctx.SubPfcpLog.Errorf("Build PFCP Session Establishment Request failed: %v", err)
 		return
@@ -288,18 +289,18 @@ func SendPfcpSessionEstablishmentRequest(
 	logger.PfcpLog.Debugf("in SendPfcpSessionEstablishmentRequest pfcpMsg.CPFSEID.Seid %v\n", pfcpMsg.CPFSEID.Seid)
 	ip := upNodeID.ResolveNodeIdToIp()
 
-	message := pfcp.Message{
-		Header: pfcp.Header{
-			Version:         pfcp.PfcpVersion,
-			MP:              1,
-			S:               pfcp.SEID_PRESENT,
-			MessageType:     pfcp.PFCP_SESSION_ESTABLISHMENT_REQUEST,
-			SEID:            0,
-			SequenceNumber:  getSeqNumber(),
-			MessagePriority: 0,
-		},
-		Body: pfcpMsg,
-	}
+	// message := pfcp.Message{
+	// 	Header: pfcp.Header{
+	// 		Version:         pfcp.PfcpVersion,
+	// 		MP:              1,
+	// 		S:               pfcp.SEID_PRESENT,
+	// 		MessageType:     pfcp.PFCP_SESSION_ESTABLISHMENT_REQUEST,
+	// 		SEID:            0,
+	// 		SequenceNumber:  getSeqNumber(),
+	// 		MessagePriority: 0,
+	// 	},
+	// 	Body: pfcpMsg,
+	// }
 
 	upaddr := &net.UDPAddr{
 		IP:   ip,


### PR DESCRIPTION
# Description

This PR does two things:
- Replace the [omec PFCP](https://github.com/omec-project/pfcp/) package with go-pfcp allowing for the deprecation of [omec PFCP](https://github.com/omec-project/pfcp/).
- Move all pfcp specific code to the pfcp directory. In other words, you won't see import of pfcp package anywhere else than in `/pfcp` . This used to be present all over the code base, making such refactoring quite difficult.

## Rationale

### Ease of life for developers

We are currently using two different projects for PFCP communication between the SMF and the UPF making it harder to understand and contribute changes involving PFCP communication. The UPF uses `wmnsk/go-pfcp` and the SMF uses `omec-project/pfcp`, both with the same purpose. Why not depend on the 1 project for PFCP communication instead of 2.

### Security and reliability

`go-pfcp` is well maintained, tracks changes to 3GPP releases, has 53 dependents (making it more likely to receive bug fixes and security patches), and has only 1 dependency ([go-cmp](https://github.com/google/go-cmp)).

### Maintainability

Archiving this repository would reduce by 1 the total number of repositories maintained for Aether, making the project easier to support with a limited amount of developers.

